### PR TITLE
Feat/disable on demand

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,12 +1,12 @@
 <Project>
     <PropertyGroup>
-        <Version>6.13.1</Version>
-        <Authors>Finbuckle LLC</Authors>
-        <Copyright>Copyright Finbuckle LLC, Andrew White, and Contributors</Copyright>
+        <Version>6.14.0</Version>
+        <Authors>Sirfull</Authors>
+        <Copyright>Copyright Sirfull and Contributors</Copyright>
         <PackageIconUrl>https://www.finbuckle.com/images/finbuckle-128x128.png</PackageIconUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageProjectUrl>https://www.finbuckle.com/MultiTenant</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/Finbuckle/Finbuckle.MultiTenant</RepositoryUrl>
+        <RepositoryUrl>https://github.com/SirFull/Finbuckle.MultiTenant</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
@@ -90,11 +90,11 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
             var predicate = Expression.Equal(leftExp, rightExp);
 
             #region Fork Sirfull
-            // build expression tree for : "IsMultiTenantEnable == False || EF.Property<string>(e, "TenantId") == TenantInfo.Id"
+            // build expression tree for : "IsMultiTenantEnabled == False || EF.Property<string>(e, "TenantId") == TenantInfo.Id"
             //                              -------------------------------
             predicate = Expression.OrElse(
                 Expression.Equal(
-                    Expression.Property(contextMemberAccessExp, nameof(IMultiTenantDbContext.IsMultiTenantEnable)),
+                    Expression.Property(contextMemberAccessExp, nameof(IMultiTenantDbContext.IsMultiTenantEnabled)),
                     Expression.Constant(false)
                 ),
                 predicate

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
@@ -89,6 +89,18 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
             // build expression tree for EF.Property<string>(e, "TenantId") == TenantInfo.Id'
             var predicate = Expression.Equal(leftExp, rightExp);
 
+            #region Fork Sirfull
+            // build expression tree for : "IsMultiTenantEnable == False || EF.Property<string>(e, "TenantId") == TenantInfo.Id"
+            //                              -------------------------------
+            predicate = Expression.OrElse(
+                Expression.Equal(
+                    Expression.Property(contextMemberAccessExp, nameof(IMultiTenantDbContext.IsMultiTenantEnable)),
+                    Expression.Constant(false)
+                ),
+                predicate
+            );
+            #endregion
+
             // combine with existing filter
             if (existingQueryFilter != null)
             {

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/IMultiTenantDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/IMultiTenantDbContext.cs
@@ -8,6 +8,6 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
         ITenantInfo TenantInfo { get; }
         TenantMismatchMode TenantMismatchMode { get; }
         TenantNotSetMode TenantNotSetMode { get; }
-        bool IsMultiTenantEnable { get; }
+        bool IsMultiTenantEnabled { get; }
     }
 }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/IMultiTenantDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/IMultiTenantDbContext.cs
@@ -8,5 +8,6 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
         ITenantInfo TenantInfo { get; }
         TenantMismatchMode TenantMismatchMode { get; }
         TenantNotSetMode TenantNotSetMode { get; }
+        bool IsMultiTenantEnable { get; }
     }
 }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
@@ -20,6 +20,8 @@ namespace Finbuckle.MultiTenant
 
         public TenantNotSetMode TenantNotSetMode { get; set; } = TenantNotSetMode.Throw;
 
+        public bool IsMultiTenantEnabled { get; set; } = true;
+
         protected MultiTenantDbContext(ITenantInfo tenantInfo)
         {
             this.TenantInfo = tenantInfo;
@@ -37,14 +39,20 @@ namespace Finbuckle.MultiTenant
 
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
         {
-            this.EnforceMultiTenant();
+            if (IsMultiTenantEnables)
+            {
+                this.EnforceMultiTenant();
+            }
             return base.SaveChanges(acceptAllChangesOnSuccess);
         }
 
         public override async Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            this.EnforceMultiTenant();
+            if (IsMultiTenantEnables)
+            {
+                this.EnforceMultiTenant();
+            }
             return await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
         }
     }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
@@ -39,7 +39,7 @@ namespace Finbuckle.MultiTenant
 
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
         {
-            if (IsMultiTenantEnables)
+            if (IsMultiTenantEnabled)
             {
                 this.EnforceMultiTenant();
             }
@@ -49,7 +49,7 @@ namespace Finbuckle.MultiTenant
         public override async Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (IsMultiTenantEnables)
+            if (IsMultiTenantEnabled)
             {
                 this.EnforceMultiTenant();
             }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
@@ -119,6 +119,8 @@ namespace Finbuckle.MultiTenant
 
         public TenantNotSetMode TenantNotSetMode { get; set; } = TenantNotSetMode.Throw;
 
+        bool IsMultiTenantEnabled { get; set; } = true;
+
         protected MultiTenantIdentityDbContext(ITenantInfo tenantInfo)
         {
             this.TenantInfo = tenantInfo;

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
@@ -119,7 +119,7 @@ namespace Finbuckle.MultiTenant
 
         public TenantNotSetMode TenantNotSetMode { get; set; } = TenantNotSetMode.Throw;
 
-        bool IsMultiTenantEnabled { get; set; } = true;
+        public bool IsMultiTenantEnabled { get; set; } = true;
 
         protected MultiTenantIdentityDbContext(ITenantInfo tenantInfo)
         {


### PR DESCRIPTION
Ajout d'un booléen permettant d'ignorer contextuellement les tenants des entités MultiTenant (à l'interrogation et sauvegarde de données)